### PR TITLE
Version 1.0.8

### DIFF
--- a/Autodesk.Forge.Oss.DesignAutomation.Tests/DA_Test.cs
+++ b/Autodesk.Forge.Oss.DesignAutomation.Tests/DA_Test.cs
@@ -47,7 +47,23 @@ namespace Autodesk.Forge.Oss.DesignAutomation.Tests
         [Test]
         public async Task GetNicknameTest()
         {
+            //await service.DeleteForgeAppAsync();
+            //await service.CreateNicknameAsync("nickname");
+
             Console.WriteLine(await service.GetNicknameAsync());
+        }
+
+        [Test]
+        public async Task GetBundles()
+        {
+            var nickname = await service.GetNicknameAsync();
+            var bundles = await service.GetAllBundlesAsync();
+            foreach (var bundle in bundles)
+            {
+                var bundleName = bundle.Split('+')[0].Replace(nickname, "").TrimStart('.');
+                Console.WriteLine($"[{bundle}] - {bundleName}");
+                // await service.DesignAutomationClient.DeleteAppBundleAsync(bundleName);
+            }
         }
 
         [Test(ExpectedResult = false)]

--- a/Autodesk.Forge.Oss.DesignAutomation.Tests/DA_Test.cs
+++ b/Autodesk.Forge.Oss.DesignAutomation.Tests/DA_Test.cs
@@ -1,8 +1,10 @@
 ﻿using Autodesk.Forge.Core;
+using Autodesk.Forge.Oss.DesignAutomation.Extensions;
 using Autodesk.Forge.Oss.DesignAutomation.Samples.Models;
 using Autodesk.Forge.Oss.DesignAutomation.Services;
 using NUnit.Framework;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Autodesk.Forge.Oss.DesignAutomation.Tests
@@ -57,6 +59,19 @@ namespace Autodesk.Forge.Oss.DesignAutomation.Tests
                 options.Result = @$"Result{Engine}.rvt";
             });
             return result;
+        }
+
+        [Explicit]
+        [Test]
+        public async Task GetEngines()
+        {
+            var engines = await PageUtils.GetAllItems(service.DesignAutomationClient.GetEnginesAsync);
+            foreach (var engine in engines.OrderBy(e => e))
+            {
+                //Console.WriteLine(engine);
+                var engineModel = await service.DesignAutomationClient.GetEngineAsync(engine);
+                Console.WriteLine(engineModel.ToJson());
+            }
         }
     }
 }

--- a/Autodesk.Forge.Oss.DesignAutomation.Tests/DA_Test.cs
+++ b/Autodesk.Forge.Oss.DesignAutomation.Tests/DA_Test.cs
@@ -68,10 +68,23 @@ namespace Autodesk.Forge.Oss.DesignAutomation.Tests
             var engines = await PageUtils.GetAllItems(service.DesignAutomationClient.GetEnginesAsync);
             foreach (var engine in engines.OrderBy(e => e))
             {
-                //Console.WriteLine(engine);
-                var engineModel = await service.DesignAutomationClient.GetEngineAsync(engine);
-                Console.WriteLine(engineModel.ToJson());
+                var engineModel = await service.DesignAutomationClient.GetEngineDateAsync(engine);
+                //var engineModel = await service.DesignAutomationClient.Service.GetEngineDateAsync(engine);
+                Console.WriteLine($"{engineModel.IsDeprecated()} \t{engineModel.ToJson()}");
             }
+        }
+
+        [Explicit]
+        [Test]
+        public async Task GetEngineRevit()
+        {
+            var engines = await PageUtils.GetAllItems(service.DesignAutomationClient.GetEnginesAsync);
+            var engine = engines.OrderBy(e => e).LastOrDefault(e => e.Contains("Revit"));
+
+            Console.WriteLine(engine);
+            var engineModel = await service.DesignAutomationClient.GetEngineDateAsync(engine);
+            //var engineModel = await service.DesignAutomationClient.Service.GetEngineDateAsync(engine);
+            Console.WriteLine($"{engineModel.IsDeprecated()} \t{engineModel.ToJson()}");
         }
     }
 }

--- a/Autodesk.Forge.Oss.DesignAutomation/Autodesk.Forge.Oss.DesignAutomation.csproj
+++ b/Autodesk.Forge.Oss.DesignAutomation/Autodesk.Forge.Oss.DesignAutomation.csproj
@@ -32,7 +32,7 @@
 
   <PropertyGroup>
     <PackageId>ricaun.Autodesk.Forge.Oss.DesignAutomation</PackageId>
-    <Version>1.0.7</Version>
+    <Version>1.0.8</Version>
     <ProjectGuid>{B2289CA1-B106-49B3-9077-6C4F28F0F50C}</ProjectGuid>
   </PropertyGroup>
 

--- a/Autodesk.Forge.Oss.DesignAutomation/DesignAutomationService.cs
+++ b/Autodesk.Forge.Oss.DesignAutomation/DesignAutomationService.cs
@@ -150,16 +150,16 @@ namespace Autodesk.Forge.Oss.DesignAutomation
             if (string.IsNullOrEmpty(CustomHeaderValue))
                 return null;
 
-            if (string.IsNullOrEmpty(lastEngineName))
+            if (string.IsNullOrEmpty(lastCustomHeaderEngineName))
                 return null;
 
-            var custom = string.Format(CustomHeaderValue, lastEngineName);
+            var custom = string.Format(CustomHeaderValue, lastCustomHeaderEngineName);
             return custom;
         }
-        private string lastEngineName;
-        private void UpdateEngineName(string engineName)
+        private string lastCustomHeaderEngineName;
+        private void UpdateCustomHeaderEngineName(string engineName)
         {
-            this.lastEngineName = engineName;
+            this.lastCustomHeaderEngineName = engineName;
         }
         #endregion
 
@@ -306,8 +306,13 @@ namespace Autodesk.Forge.Oss.DesignAutomation
             // Engine
             {
                 var engineId = $"{CoreEngine()}+{GetEngineVersion(engine)}";
-                var engineModel = await this.designAutomationClient.GetEngineAsync(engineId);
+                var engineModel = await this.designAutomationClient.GetEngineDateAsync(engineId);
+                var isDeprecated = engineModel.IsDeprecated();
                 WriteLine($"[Engine]: {engineModel.ToJson()}");
+                if (isDeprecated)
+                {
+                    WriteLine($"[Engine]: {engineId} is deprecated.");
+                }
             }
 
             // Activity
@@ -415,7 +420,7 @@ namespace Autodesk.Forge.Oss.DesignAutomation
             {
                 engineResult = $"{CoreEngine()}+{GetEngineVersion(engine)}";
             }
-            UpdateEngineName(engineResult);
+            UpdateCustomHeaderEngineName(engineResult);
             return engineResult;
         }
         #endregion

--- a/Autodesk.Forge.Oss.DesignAutomation/DesignAutomationService.cs
+++ b/Autodesk.Forge.Oss.DesignAutomation/DesignAutomationService.cs
@@ -477,7 +477,12 @@ namespace Autodesk.Forge.Oss.DesignAutomation
             }
         }
 
-        internal async Task<IEnumerable<string>> GetAllBundlesAsync(bool account = true)
+        /// <summary>
+        /// GetAllBundlesAsync
+        /// </summary>
+        /// <param name="account"></param>
+        /// <returns></returns>
+        public async Task<IEnumerable<string>> GetAllBundlesAsync(bool account = true)
         {
             var data = await PageUtils.GetAllItems(this.designAutomationClient.GetAppBundlesAsync);
             if (account)

--- a/Autodesk.Forge.Oss.DesignAutomation/DesignAutomationService.cs
+++ b/Autodesk.Forge.Oss.DesignAutomation/DesignAutomationService.cs
@@ -144,22 +144,58 @@ namespace Autodesk.Forge.Oss.DesignAutomation
         /// CustomHeaderValue (default: Environment Variable => "FORGE_CLIENT_CUSTOM_HEADER_VALUE")
         /// <code>x-custom-header: engine value is {0}</code>
         /// </summary>
+        /// <remarks>The custom header is only enabled if the engine is deprecated.</remarks>
         public string CustomHeaderValue { get; init; }
-        private string GetCustomHeaderValue()
+        private string GetCustomHeaderValue(string contentRequest)
         {
             if (string.IsNullOrEmpty(CustomHeaderValue))
                 return null;
 
-            if (string.IsNullOrEmpty(lastCustomHeaderEngineName))
+            string customHeaderEngineName = null;
+            foreach (var key in EnableCustomHeaderValue.Keys)
+            {
+                if (contentRequest.Contains(key))
+                {
+                    customHeaderEngineName = key;
+                }
+            }
+
+            if (string.IsNullOrEmpty(customHeaderEngineName))
                 return null;
 
-            var custom = string.Format(CustomHeaderValue, lastCustomHeaderEngineName);
+            if (EnableCustomHeaderValue.TryGetValue(customHeaderEngineName, out bool isEnabled))
+            {
+#if DEBUG
+                WriteLine($" - [ContentRequest] {contentRequest}");
+                WriteLine($" - [GetCustomHeaderValue]: {customHeaderEngineName} custom header is '{isEnabled}'.");
+#endif
+                if (isEnabled == false)
+                    return null;
+            }
+
+            var custom = string.Format(CustomHeaderValue, customHeaderEngineName);
             return custom;
         }
-        private string lastCustomHeaderEngineName;
+        private Dictionary<string, bool> EnableCustomHeaderValue { get; set; } = new();
         private void UpdateCustomHeaderEngineName(string engineName)
         {
-            this.lastCustomHeaderEngineName = engineName;
+            if (string.IsNullOrEmpty(CustomHeaderValue))
+                return;
+
+            if (EnableCustomHeaderValue.ContainsKey(engineName) == false)
+            {
+                EnableCustomHeaderValue[engineName] = false;
+                try
+                {
+                    var engineModel = this.designAutomationClient.GetEngineDateAsync(engineName).Result;
+                    var isDeprecated = engineModel.IsDeprecated();
+                    EnableCustomHeaderValue[engineName] = isDeprecated;
+#if DEBUG
+                    WriteLine($" - [UpdateCustomHeaderEngineName]: {engineName} custom header is '{isDeprecated}'.");
+#endif
+                }
+                catch { }
+            }
         }
         #endregion
 
@@ -308,7 +344,7 @@ namespace Autodesk.Forge.Oss.DesignAutomation
                 var engineId = $"{CoreEngine()}+{GetEngineVersion(engine)}";
                 var engineModel = await this.designAutomationClient.GetEngineDateAsync(engineId);
                 var isDeprecated = engineModel.IsDeprecated();
-                WriteLine($"[Engine]: {engineModel.ToJson()}");
+                WriteLine($"[Engine]: {engineId} - {engineModel.ToJson()}");
                 if (isDeprecated)
                 {
                     WriteLine($"[Engine]: {engineId} is deprecated.");

--- a/Autodesk.Forge.Oss.DesignAutomation/Extensions/DesignAutomationEngineDateUtils.cs
+++ b/Autodesk.Forge.Oss.DesignAutomation/Extensions/DesignAutomationEngineDateUtils.cs
@@ -1,0 +1,139 @@
+﻿using Autodesk.Forge.Core;
+using Autodesk.Forge.DesignAutomation;
+using Autodesk.Forge.DesignAutomation.Model;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+
+namespace Autodesk.Forge.Oss.DesignAutomation.Extensions
+{
+    /// <summary>
+    /// ForgeServiceUtils
+    /// </summary>
+    public static class DesignAutomationEngineDateUtils
+    {
+        /// <summary>
+        /// EngineDate
+        /// </summary>
+        public class EngineDate : Engine
+        {
+            /// <summary>
+            /// The deprecation date of the engine.
+            /// </summary>
+            [DataMember(Name = "deprecationDate", EmitDefaultValue = false)]
+            public DateOnly DeprecationDate { get; set; }
+        }
+
+        /// <summary>
+        /// Check if the <paramref name="engine"/> is deprecated base on the <see cref="EngineDate.DeprecationDate"/>.
+        /// </summary>
+        /// <param name="engine"></param>
+        /// <param name="addDayOffset"></param>
+        /// <returns></returns>
+        public static bool IsDeprecated(this EngineDate engine, int addDayOffset = 1)
+        {
+            if (engine.DeprecationDate == default) return false;
+
+            var dateOnlyNow = DateOnly.FromDateTime(DateTime.UtcNow.Date)
+                .AddDays(addDayOffset);
+
+            return engine.DeprecationDate <= dateOnlyNow;
+        }
+
+        /// <summary>
+        /// GetEngineDateAsync
+        /// </summary>
+        /// <param name="designAutomationClient"></param>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public static async Task<EngineDate> GetEngineDateAsync(
+            this DesignAutomationClient designAutomationClient,
+            string id)
+        {
+            return await designAutomationClient.Service.GetEngineDateAsync(id);
+        }
+
+        /// <summary>
+        /// GetEngineDateAsync
+        /// </summary>
+        /// <param name="service"></param>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public static async Task<EngineDate> GetEngineDateAsync(
+            this ForgeService service,
+            string id)
+        {
+            var result = await GetAsync<EngineDate>(service, "/v3/engines/{id}", new Dictionary<string, object> { { "id", id } });
+            return result.Content;
+        }
+
+        /// <summary>
+        /// GetAsync
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="service"></param>
+        /// <param name="relativePath"></param>
+        /// <param name="routeParameters"></param>
+        /// <param name="queryParameters"></param>
+        /// <param name="scopes"></param>
+        /// <param name="headers"></param>
+        /// <param name="throwOnError"></param>
+        /// <returns></returns>
+        public static async Task<ApiResponse<T>> GetAsync<T>(
+            this ForgeService service,
+            string relativePath,
+            Dictionary<string, object> routeParameters = null,
+            Dictionary<string, object> queryParameters = null,
+            string scopes = null,
+            IDictionary<string, string> headers = null,
+            bool throwOnError = true)
+        {
+            using (var request = new HttpRequestMessage())
+            {
+                request.RequestUri =
+                    Marshalling.BuildRequestUri(relativePath,
+                        routeParameters: routeParameters ?? new Dictionary<string, object>(),
+                        queryParameters: queryParameters ?? new Dictionary<string, object>()
+                    );
+
+                request.Headers.TryAddWithoutValidation("Accept", "application/json");
+                if (headers != null)
+                {
+                    foreach (var header in headers)
+                    {
+                        request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
+                }
+
+                // tell the underlying pipeline what scope we'd like to use
+                if (scopes == null)
+                {
+                    request.Options.Set(ForgeConfiguration.ScopeKey, "code:all");
+                }
+                else
+                {
+                    request.Options.Set(ForgeConfiguration.ScopeKey, scopes);
+                }
+
+                request.Method = new HttpMethod("GET");
+
+                // make the HTTP request
+                var response = await service.Client.SendAsync(request);
+
+                if (throwOnError)
+                {
+                    await response.EnsureSuccessStatusCodeAsync();
+                }
+                else if (!response.IsSuccessStatusCode)
+                {
+                    return new ApiResponse<T>(response, default(T));
+                }
+
+                return new ApiResponse<T>(response, await Marshalling.DeserializeAsync<T>(response.Content));
+
+            } // using
+        }
+    }
+}

--- a/Build/.nuke/build.schema.json
+++ b/Build/.nuke/build.schema.json
@@ -72,6 +72,9 @@
             "type": "string"
           }
         },
+        "ReleaseFolder": {
+          "type": "string"
+        },
         "ReleaseNameVersion": {
           "type": "boolean"
         },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.8] / 2023-12-07
+### Updated
+- Add `DesignAutomationEngineDateUtils` to enable `DeprecationDate` on Engine.
+
 ## [1.0.7] / 2023-10-03
 ### Updated
 - Update `ParameterActivityLanguageAttribute` to ignore empty value (Fix: #9)
@@ -42,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - First Release (Copy project from: [RevitAddin.DA.Tester](https://github.com/ricaun-io/RevitAddin.DA.Tester/tree/package))
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.0.8]: ../../compare/1.0.7...1.0.8
 [1.0.7]: ../../compare/1.0.6...1.0.7
 [1.0.6]: ../../compare/1.0.5...1.0.6
 [1.0.5]: ../../compare/1.0.4...1.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.8] / 2023-12-07
 ### Updated
 - Add `DesignAutomationEngineDateUtils` to enable `DeprecationDate` on Engine.
+- Update `ForgeCustomHeaderValueHandler` with content and only when engine is deprecated.
+- Update `UpdateCustomHeaderEngineName` to check if engine is deprecated.
 
 ## [1.0.7] / 2023-10-03
 ### Updated

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ FORGE_CLIENT_SECRET=<your client secret>
 
 #### Custom
 
-You can define a custom header to be sent with each Design Automation requests to the Forge API. 
+You can define a custom header to be sent with each Design Automation requests to the Forge API.
+**The custom header is only enabled if the engine is deprecated.**
 
 ```bash
 FORGE_CLIENT_CUSTOM_HEADER_VALUE=<your custom header>


### PR DESCRIPTION
### Updated
- Add `DesignAutomationEngineDateUtils` to enable `DeprecationDate` on Engine.
- Update `ForgeCustomHeaderValueHandler` with content and only when engine is deprecated.
- Update `UpdateCustomHeaderEngineName` to check if engine is deprecated.