### PR TITLE
Version 2.0.0

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -20,11 +20,9 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: NuGet Setup
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
-      - name: "NuGet Add Source Organization"
-        run: if ("${{ secrets.ORGANIZATION_SOURCE_PACKAGE_PASSWORD }}" -ne "") { dotnet nuget add source --username ${{ secrets.ORGANIZATION_SOURCE_PACKAGE_USERNAME }} --password ${{ secrets.ORGANIZATION_SOURCE_PACKAGE_PASSWORD }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{github.repository_owner}}/index.json" }
+          dotnet-version: 8.0.x
 
       - name: Run './build/build.cmd'
         run: ./build/build.cmd --root ./build

--- a/Autodesk.Forge.Oss.DesignAutomation.Tests/Autodesk.Forge.Oss.DesignAutomation.Tests.csproj
+++ b/Autodesk.Forge.Oss.DesignAutomation.Tests/Autodesk.Forge.Oss.DesignAutomation.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Autodesk.Forge.Oss.DesignAutomation/Autodesk.Forge.Oss.DesignAutomation.csproj
+++ b/Autodesk.Forge.Oss.DesignAutomation/Autodesk.Forge.Oss.DesignAutomation.csproj
@@ -32,7 +32,7 @@
 
   <PropertyGroup>
     <PackageId>ricaun.Autodesk.Forge.Oss.DesignAutomation</PackageId>
-    <Version>2.0.0-beta</Version>
+    <Version>2.0.0</Version>
     <ProjectGuid>{B2289CA1-B106-49B3-9077-6C4F28F0F50C}</ProjectGuid>
   </PropertyGroup>
 
@@ -92,9 +92,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ricaun.Autodesk.Forge.Oss" Version="*-*" />
+    <PackageReference Include="ricaun.Autodesk.Forge.Oss" Version="*" />
     <PackageReference Include="Autodesk.Forge.DesignAutomation" Version="5.*" Condition="$(TargetFramework.Contains('net6'))" />
-    <PackageReference Include="Autodesk.Forge.DesignAutomation" Version="6.*" Condition="$(TargetFramework.Contains('net8'))" />
+    <PackageReference Include="Autodesk.Forge.DesignAutomation" Version="*" Condition="$(TargetFramework.Contains('net8'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Autodesk.Forge.Oss.DesignAutomation/Autodesk.Forge.Oss.DesignAutomation.csproj
+++ b/Autodesk.Forge.Oss.DesignAutomation/Autodesk.Forge.Oss.DesignAutomation.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>latest</LangVersion>
@@ -92,8 +92,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ricaun.Autodesk.Forge.Oss" Version="*" />
-    <PackageReference Include="Autodesk.Forge.DesignAutomation" Version="*" />
+    <PackageReference Include="ricaun.Autodesk.Forge.Oss" Version="*-*" />
+    <PackageReference Include="Autodesk.Forge.DesignAutomation" Version="5.*" Condition="$(TargetFramework.Contains('net6'))" />
+    <PackageReference Include="Autodesk.Forge.DesignAutomation" Version="6.*" Condition="$(TargetFramework.Contains('net8'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Autodesk.Forge.Oss.DesignAutomation/Autodesk.Forge.Oss.DesignAutomation.csproj
+++ b/Autodesk.Forge.Oss.DesignAutomation/Autodesk.Forge.Oss.DesignAutomation.csproj
@@ -32,7 +32,7 @@
 
   <PropertyGroup>
     <PackageId>ricaun.Autodesk.Forge.Oss.DesignAutomation</PackageId>
-    <Version>1.0.8</Version>
+    <Version>2.0.0-beta</Version>
     <ProjectGuid>{B2289CA1-B106-49B3-9077-6C4F28F0F50C}</ProjectGuid>
   </PropertyGroup>
 

--- a/Build/.nuke/build.schema.json
+++ b/Build/.nuke/build.schema.json
@@ -137,6 +137,9 @@
         "TestLocalResults": {
           "type": "boolean"
         },
+        "UnlistNuget": {
+          "type": "boolean"
+        },
         "Verbosity": {
           "type": "string",
           "description": "Logging verbosity during build execution. Default is 'Normal'",

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -3,7 +3,7 @@ using Nuke.Common.Execution;
 using ricaun.Nuke;
 using ricaun.Nuke.Components;
 
-class Build : NukeBuild, IPublishPack, ITestLocal
+class Build : NukeBuild, IPublishPack, ITestLocal, IPrePack
 {
     public static int Main() => Execute<Build>(x => x.From<IPublishPack>().Build);
 }

--- a/Build/Build.csproj
+++ b/Build/Build.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>.</NukeRootDirectory>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] / 2024-08-20
+### Updated
+- Update `ricaun.Autodesk.Forge.Oss` to `2.0.0` to fix auth issue.
+
 ## [1.0.8] / 2023-12-07
 ### Updated
 - Add `DesignAutomationEngineDateUtils` to enable `DeprecationDate` on Engine.
@@ -48,6 +52,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - First Release (Copy project from: [RevitAddin.DA.Tester](https://github.com/ricaun-io/RevitAddin.DA.Tester/tree/package))
 
 [vNext]: ../../compare/1.0.0...HEAD
+[2.0.0]: ../../compare/1.0.8...2.0.0
 [1.0.8]: ../../compare/1.0.7...1.0.8
 [1.0.7]: ../../compare/1.0.6...1.0.7
 [1.0.6]: ../../compare/1.0.5...1.0.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [2.0.0] / 2024-08-20
+### Features
+- Support .NET 6.0 and .NET 8.0
 ### Updated
 - Update `ricaun.Autodesk.Forge.Oss` to `2.0.0` to fix auth issue.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Build](https://github.com/ricaun-io/forge-api-dotnet-oss.design.automation/actions/workflows/Build.yml/badge.svg)](https://github.com/ricaun-io/forge-api-dotnet-oss.design.automation/actions)
 [![.NET 6.0](https://img.shields.io/badge/.NET%206.0-blue.svg)](https://github.com/ricaun-io/forge-api-dotnet-oss.design.automation)
-[![Release](https://img.shields.io/nuget/v/ricaun.Autodesk.Forge.Oss.DesignAutomation?logo=nuget&label=release&color=blue)](https://www.nuget.org/packages/ricaun.Autodesk.Forge.Oss.DesignAutomation)
+[![Nuget](https://img.shields.io/nuget/v/ricaun.Autodesk.Forge.Oss.DesignAutomation?logo=nuget&label=nuget&color=blue)](https://www.nuget.org/packages/ricaun.Autodesk.Forge.Oss.DesignAutomation)
 
 ### PackageReference
 


### PR DESCRIPTION
### Features
- Support .NET 6.0 and .NET 8.0
### Updated
- Update `ricaun.Autodesk.Forge.Oss` to `2.0.0` to fix auth issue.