### PR TITLE
Version 3.0.0

### DIFF
--- a/Autodesk.Forge.Oss.DesignAutomation.App/Program.cs
+++ b/Autodesk.Forge.Oss.DesignAutomation.App/Program.cs
@@ -37,6 +37,7 @@ namespace Autodesk.Forge.Oss.DesignAutomation.App
                 EnableParameterConsoleLogger = true,
                 EnableReportConsoleLogger = true,
                 RunTimeOutMinutes = 1,
+                //BucketRegion="EMEA",
             };
 
             await service.Initialize(@".\DA\DA4Revit\DeleteWalls.zip");

--- a/Autodesk.Forge.Oss.DesignAutomation.sln
+++ b/Autodesk.Forge.Oss.DesignAutomation.sln
@@ -10,15 +10,16 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution", "Solution", "{515EBC53-0951-4B74-90A2-BB78830725AC}"
 	ProjectSection(SolutionItems) = preProject
 		CHANGELOG.md = CHANGELOG.md
+		Directory.Build.props = Directory.Build.props
 		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Autodesk.Forge.Oss.DesignAutomation.Tests", "Autodesk.Forge.Oss.DesignAutomation.Tests\Autodesk.Forge.Oss.DesignAutomation.Tests.csproj", "{F6F94337-FC3F-4183-A332-A22198E55EE4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Autodesk.Forge.Oss.DesignAutomation.Samples", "Autodesk.Forge.Oss.DesignAutomation.Samples\Autodesk.Forge.Oss.DesignAutomation.Samples.csproj", "{FCCAD1CB-BE59-40A5-AFC1-C97B63531B82}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Autodesk.Forge.Oss.DesignAutomation.Samples", "Autodesk.Forge.Oss.DesignAutomation.Samples\Autodesk.Forge.Oss.DesignAutomation.Samples.csproj", "{FCCAD1CB-BE59-40A5-AFC1-C97B63531B82}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Autodesk.Forge.Oss.DesignAutomation.App", "Autodesk.Forge.Oss.DesignAutomation.App\Autodesk.Forge.Oss.DesignAutomation.App.csproj", "{4CE6201C-DE04-437F-AF4B-5745B9F43C32}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Autodesk.Forge.Oss.DesignAutomation.App", "Autodesk.Forge.Oss.DesignAutomation.App\Autodesk.Forge.Oss.DesignAutomation.App.csproj", "{4CE6201C-DE04-437F-AF4B-5745B9F43C32}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Autodesk.Forge.Oss.DesignAutomation/Autodesk.Forge.Oss.DesignAutomation.csproj
+++ b/Autodesk.Forge.Oss.DesignAutomation/Autodesk.Forge.Oss.DesignAutomation.csproj
@@ -95,7 +95,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ricaun.Autodesk.Forge.Oss" Version="*-*" />
+    <PackageReference Include="ricaun.Autodesk.Forge.Oss" Version="*" />
     <PackageReference Include="Autodesk.Forge.DesignAutomation" Version="5.*" Condition="$(TargetFramework.Contains('net6'))" />
     <PackageReference Include="Autodesk.Forge.DesignAutomation" Version="*" Condition="$(TargetFramework.Contains('net8'))" />
   </ItemGroup>

--- a/Autodesk.Forge.Oss.DesignAutomation/Autodesk.Forge.Oss.DesignAutomation.csproj
+++ b/Autodesk.Forge.Oss.DesignAutomation/Autodesk.Forge.Oss.DesignAutomation.csproj
@@ -62,10 +62,6 @@
 
   <PropertyGroup Condition="!$(Configuration.Contains('Debug'))">
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>Full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition="$(Configuration.Contains('Debug'))">
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/Autodesk.Forge.Oss.DesignAutomation/Autodesk.Forge.Oss.DesignAutomation.csproj
+++ b/Autodesk.Forge.Oss.DesignAutomation/Autodesk.Forge.Oss.DesignAutomation.csproj
@@ -32,7 +32,6 @@
 
   <PropertyGroup>
     <PackageId>ricaun.Autodesk.Forge.Oss.DesignAutomation</PackageId>
-    <Version>2.1.0</Version>
     <ProjectGuid>{B2289CA1-B106-49B3-9077-6C4F28F0F50C}</ProjectGuid>
   </PropertyGroup>
 
@@ -63,6 +62,10 @@
 
   <PropertyGroup Condition="!$(Configuration.Contains('Debug'))">
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition="$(Configuration.Contains('Debug'))">
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -92,7 +95,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ricaun.Autodesk.Forge.Oss" Version="*" />
+    <PackageReference Include="ricaun.Autodesk.Forge.Oss" Version="*-*" />
     <PackageReference Include="Autodesk.Forge.DesignAutomation" Version="5.*" Condition="$(TargetFramework.Contains('net6'))" />
     <PackageReference Include="Autodesk.Forge.DesignAutomation" Version="*" Condition="$(TargetFramework.Contains('net8'))" />
   </ItemGroup>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] / 2024-12-13
+### Features
+- Support `region` bucket.
+### Updated
+- Update `ricaun.Autodesk.Forge.Oss` to `3.0.0` to fix `region` bucket.
+- Add `BucketRegion` to `DesignAutomationService`.
+- Add `BucketRegion` with `APS_CLIENT_BUCKET_REGION` or `FORGE_CLIENT_BUCKET_REGION`
+- Update `Delete` to delete `bucket` to recreate with `region`.
+
 ## [2.1.0] / 2024-12-12
 ### Updated
 - Update `Oss` to use upload files in `s3`. (Fix: #16)
@@ -59,6 +68,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - First Release (Copy project from: [RevitAddin.DA.Tester](https://github.com/ricaun-io/RevitAddin.DA.Tester/tree/package))
 
 [vNext]: ../../compare/1.0.0...HEAD
+[3.0.0]: ../../compare/2.1.0...3.0.0
 [2.1.0]: ../../compare/2.0.0...2.1.0
 [2.0.0]: ../../compare/1.0.8...2.0.0
 [1.0.8]: ../../compare/1.0.7...1.0.8

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>3.0.0-rc</Version>
+		<Version>3.0.0</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+	<PropertyGroup>
+		<Version>3.0.0-alpha</Version>
+	</PropertyGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>3.0.0-alpha</Version>
+		<Version>3.0.0-rc</Version>
 	</PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ FORGE_CLIENT_ID=<your client id>
 FORGE_CLIENT_SECRET=<your client secret>
 ```
 
+#### Region
+
+You can define the region of the bucket. [Available regions](https://aps.autodesk.com/en/docs/data/v2/reference/http/buckets-POST/)
+
+```bash
+APS_CLIENT_BUCKET_REGION=<region>
+```
+
+or
+
+```bash
+FORGE_CLIENT_BUCKET_REGION=<region>
+```
+
 #### Custom
 
 You can define a custom header to be sent with each Design Automation requests to the Forge API.


### PR DESCRIPTION
### Features
- Support `region` bucket.
### Updated
- Update `ricaun.Autodesk.Forge.Oss` to `3.0.0` to fix `region` bucket.
- Add `BucketRegion` to `DesignAutomationService`.
- Add `BucketRegion` with `APS_CLIENT_BUCKET_REGION` or `FORGE_CLIENT_BUCKET_REGION`
- Update `Delete` to delete `bucket` to recreate with `region`.
